### PR TITLE
Add an API for activating NVTX from CUDA.jl.

### DIFF
--- a/src/NVTX.jl
+++ b/src/NVTX.jl
@@ -3,26 +3,39 @@ module NVTX
 import Colors, Libdl
 using NVTX_jll, JuliaNVTXCallbacks_jll
 
-const NSYS_ACTIVE = Ref{Bool}(false)
+const NVTX_ACTIVE = Ref{Bool}(false)
 
 """
     NVTX.isactive()
 
 Determine if Nsight Systems profiling is currently active.
 """
-isactive() = NSYS_ACTIVE[]
+isactive() = NVTX_ACTIVE[]
+
+"""
+    NVTX.activate()
+
+Activate the NVTX APIs. This is called automatically when importing NVTX.jl while
+running under Nsight profilers. It can also be called manually to enable NVTX when
+running under a different profiler that is compatible with NVTX. Note that in such
+cases, you may have to manually set the `NVTX_INJECTION64_PATH` environment variable
+and have it point to a library that can handle the NVTX APIs.
+"""
+function activate()
+    NVTX_ACTIVE[] = true
+    initialize()
+    name_threads_julia()
+    callbacks = split(get(ENV, "JULIA_NVTX_CALLBACKS", ""), [',','|'])
+    enable_gc_hooks(;
+        gc="gc" in callbacks,
+        alloc="alloc" in callbacks,
+        free="free" in callbacks
+    )
+end
 
 function __init__()
-    if haskey(ENV, "NSYS_PROFILING_SESSION_ID")
-        NSYS_ACTIVE[] = true
-        initialize()
-        name_threads_julia()
-        callbacks = split(get(ENV, "JULIA_NVTX_CALLBACKS", ""), [',','|'])
-        enable_gc_hooks(;
-            gc="gc" in callbacks,
-            alloc="alloc" in callbacks,
-            free="free" in callbacks
-        )
+    if haskey(ENV, "NVTX_INJECTION32_PATH") || haskey(ENV, "NVTX_INJECTION64_PATH")
+        activate()
     end
 end
 


### PR DESCRIPTION
Alternative to https://github.com/JuliaGPU/NVTX.jl/pull/33. Fixes https://github.com/JuliaGPU/NVTX.jl/issues/32.
Should make it possible for `CUDA.@profile` to receive NVTX events, when not running under NSight.

It does not fix https://github.com/JuliaGPU/NVTX.jl/issues/8, but I don't think we can, because NVTX needs to know at the time of the first API call which library is used to handle events (using the `NVTX_INJECTION64_PATH` env var, normally).